### PR TITLE
Fix docstring formatting in LLM client

### DIFF
--- a/app/llm_client.py
+++ b/app/llm_client.py
@@ -1,7 +1,6 @@
-"""Remove mock mode fallback when Gemini fails."""
-"""
-Local LLM client for quiz generation
-Integrated with Ollama for real LLM calls
+"""Local LLM client for quiz generation.
+
+Integrated with Ollama for real LLM calls.
 """
 
 from typing import List, Optional, Dict, Any


### PR DESCRIPTION
## Summary
- clean up the module docstring in `llm_client`
- ensure the file ends with a newline

## Testing
- `find app -name '*.py' | xargs python -m py_compile`

------
https://chatgpt.com/codex/tasks/task_e_6840213f9a48832cb1d70e4edd7933e6