### PR TITLE
Update README with launch instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,30 +1,27 @@
 # Quiz Generator
 
-A local web application for generating quizzes from uploaded study materials using FastAPI backend and React frontend, designed for self-hosted LLM integration.
+A local web application that lets you generate quizzes from your study material. The backend is powered by FastAPI while the frontend is built with React.
 
 ## Features
 
-- **File Upload**: Support for PDF, DOCX, and TXT files
-- **Text Extraction**: Automatic text extraction from uploaded documents
-- **Quiz Generation**: AI-powered quiz generation using local LLM
-- **Quiz Management**: View, edit, and organize your quizzes
-- **Interactive Quiz Taking**: Study mode and test mode with progress tracking
+- **File Upload**: Supports PDF, DOCX and TXT files
+- **Text Extraction**: Automatically extracts text from uploaded documents
+- **Quiz Generation**: AI powered quiz generation using a local LLM
+- **Quiz Management**: View, edit and organize quizzes
+- **Interactive Quiz Taking**: Study and test modes with progress tracking
 
 ## Tech Stack
 
 ### Backend
-- **FastAPI**: Python web framework for the API
-- **PyMuPDF**: PDF text extraction
-- **python-docx**: DOCX file processing
-- **Pydantic**: Data validation and serialization
-- **Uvicorn**: ASGI server
+- **FastAPI** for the API layer
+- **PyMuPDF** and **python-docx** for document parsing
+- **Pydantic** for data validation
+- **Uvicorn** as the ASGI server
 
 ### Frontend
-- **React 18**: Modern React with hooks
-- **TypeScript**: Type-safe JavaScript
-- **Vite**: Fast build tool and dev server
-- **Tailwind CSS**: Utility-first CSS framework
-- **Axios**: HTTP client for API calls
+- **React 18** with TypeScript
+- **Vite** for building the frontend
+- **Tailwind CSS** for styling
 
 ## Prerequisites
 
@@ -34,8 +31,38 @@ A local web application for generating quizzes from uploaded study materials usi
 
 ## Installation
 
-### 1. Clone the Repository
+### 1. Clone the repository
 
 ```bash
 git clone https://github.com/tonylinpakkin/quiz_generator
-cd quiz-generator
+cd quiz_generator
+```
+
+### 2. Run the setup script
+
+The project ships with a helper script that installs Python and Node dependencies, builds the frontend and prepares the environment:
+
+```bash
+./setup.sh
+```
+
+After the script finishes, review the generated `.env` file and set `LLM_MOCK_MODE=false` when you are ready to use a real LLM.
+
+## Launching the application
+
+1. Activate the Python virtual environment and start the backend:
+
+   ```bash
+   source venv/bin/activate
+   python main.py
+   ```
+
+2. In another terminal, start the React development server:
+
+   ```bash
+   npm run dev
+   ```
+
+3. Open <http://localhost:5000> in your browser.
+
+The backend listens on port 5000 by default. You can change the port by setting the `PORT` environment variable before starting `main.py`.


### PR DESCRIPTION
## Summary
- update installation section
- add steps describing how to start the backend and frontend

## Testing
- `python -m pytest -q` *(fails: ModuleNotFoundError: No module named 'fitz')*

------
https://chatgpt.com/codex/tasks/task_e_68451db03c70832c817ac4710ff84176