### PR TITLE
Fix setup .env missing

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,25 @@
+# Environment configuration for Quiz Generator
+
+# Use mock mode for LLM responses. Set to "false" when connecting to a real model
+LLM_MOCK_MODE=true
+
+# Name of the local LLM model
+LLM_MODEL=llama3.2
+
+# Request timeout for LLM calls in seconds
+LLM_TIMEOUT=120
+
+# Allow using Google Gemini as a fallback
+USE_GEMINI=true
+
+# Gemini API key (leave empty to disable)
+GEMINI_API_KEY=
+
+# Gemini model name
+GEMINI_MODEL=gemini-2.0-flash
+
+# Optional PostgreSQL database URL
+DATABASE_URL=
+
+# Backend server port
+PORT=5000


### PR DESCRIPTION
## Summary
- add `.env.example` so the setup script can create `.env`

## Testing
- `pip install -e .`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68452124c290832cbc69927b53972503