### PR TITLE
fix quiz generation call

### DIFF
--- a/src/components/FileUpload.tsx
+++ b/src/components/FileUpload.tsx
@@ -77,9 +77,10 @@ const FileUpload: React.FC<FileUploadProps> = ({
   const [isLoading, setIsLoading] = useState(false);
 
   const handleGenerateQuiz = async () => {
+    if (!selectedFile) return;
     try {
       setIsLoading(true);
-      await onGenerateQuiz(selectedFile.file_id, quizOptions);
+      await onGenerateQuiz(selectedFile, quizOptions);
       setShowQuizOptions(false);
     } catch (error: any) {
       console.error("Failed to generate quiz:", error);


### PR DESCRIPTION
## Summary
- call `onGenerateQuiz` with the file id string directly
- guard against no file being selected

## Testing
- `npm run build`
- `PYTHONPATH=$PWD pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68453910f91c832cb86d64e6b8d1fc91