### PR TITLE
Fix documentation for npm run dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,9 @@ After the script finishes, review the generated `.env` file and set `LLM_MOCK_MO
    ```bash
    npm run dev
    ```
+   Make sure you run this command from the project root where `package.json`
+   resides, otherwise npm will output an `ENOENT` error about a missing
+   `package.json`.
 
 3. Open <http://localhost:5000> in your browser.
 


### PR DESCRIPTION
## Summary
- clarify that `npm run dev` must be executed from the project root

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684533fc9bf8832ca95955bf896c8952